### PR TITLE
Fix sender email address retrieval

### DIFF
--- a/outlookcustomtasks/__main__.py
+++ b/outlookcustomtasks/__main__.py
@@ -269,15 +269,6 @@ def group_by_sender_email_address(messages):
             # get sender's email address
             sender_email_address = get_sender_email_address(message)
             
-            # # NOTE: for debugging
-            # if sender_email_address is None:
-            #     print("Refusing to group sender by email address when email address is None!")
-            #     print(sender_email_address)
-            #     _inspect_thing('message',message)
-            #     print(message.Subject)
-            #     print("second attempt:",get_sender_email_address(message))
-            #     exit()
-
             # if no emails from sender yet
             if not sender_email_address in grouped_by_sender:
                 # create empty array for sender messages
@@ -327,19 +318,9 @@ def get_sender_email_address(message):
                     return message.SenderEmailAddress
             else:
                 return message.SenderEmailAddress
-        # elif message.Class == CALENDAR_ITEM_CLASS_ID:
-        #     print(message.Subject) # TODO: temp
-        #     return "[N/A] Calendar Item"
-        #     # return "[N/A] Calendar Item (sent by {message.SenderName})"
-        # elif message.Class == MEETING_REQUEST_CLASS_ID:
-        #     print(message.Subject) # TODO: temp
-        #     return "[N/A] Meeting Request"
-        #     # return "[N/A] Meeting Request (sent by {message.SenderName})"
         else:
             try:
                 sender_name = message.SenderName
-                # return f"[N/A] {message.MessageClass}"
-                # raise TypeError(f"is not a mail item ([.Class]: {message.Class} [.MessageClass: {message.MessageClass}])")
             except Exception as err:
                 print(f"{Fore.YELLOW}Warning: unable to get sender name for message with subject \"{message.Subject}\"{Style.RESET_ALL}: {err}")
                 sender_name = "[UNKNOWN]"
@@ -350,10 +331,6 @@ def get_sender_email_address(message):
         raise err
     except Exception as err:
         print(f"{Fore.YELLOW}Warning: unknown sender email address for message with subject \"{message.Subject}\"{Style.RESET_ALL}: {err}")
-
-        # TODO: temp
-        # _inspect_thing('message',message)
-        # raise err
 
         return None
 

--- a/outlookcustomtasks/__main__.py
+++ b/outlookcustomtasks/__main__.py
@@ -268,7 +268,7 @@ def group_by_sender_email_address(messages):
         for message in messages:
             # get sender's email address
             sender_email_address = get_sender_email_address(message)
-            
+
             # if no emails from sender yet
             if not sender_email_address in grouped_by_sender:
                 # create empty array for sender messages

--- a/outlookcustomtasks/__main__.py
+++ b/outlookcustomtasks/__main__.py
@@ -269,6 +269,15 @@ def group_by_sender_email_address(messages):
         for message in messages:
             # get sender's email address
             sender_email_address = get_sender_email_address(message)
+            
+            # # NOTE: for debugging
+            # if sender_email_address is None:
+            #     print("Refusing to group sender by email address when email address is None!")
+            #     print(sender_email_address)
+            #     _inspect_thing('message',message)
+            #     print(message.Subject)
+            #     print("second attempt:",get_sender_email_address(message))
+            #     exit()
 
             # if no emails from sender yet
             if not sender_email_address in grouped_by_sender:

--- a/outlookcustomtasks/__main__.py
+++ b/outlookcustomtasks/__main__.py
@@ -15,6 +15,8 @@ from outlookcustomtasks.settings import get_settings
 # --- CONSTANTS ---
 # ----------------
 MOVE_RESPONSE_DEFAULT = "n"
+BASIC_ANALYTICS_SUBJECT_LIMIT = 10
+SENDER_ANALYTICS_SENDER_LIMIT = 20
 
 # ---------------------
 # --- INITIALIZATION ---
@@ -188,8 +190,6 @@ def run_rule(rule, all_folders):
                 # GET TOP 10 IDENTICAL SUBJECTS REGARDLESS OF SENDER #
                 # ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-                LIMIT = 10
-                
                 messages_grouped_by_subject = group_by_subject(matches)
 
                 subjects = [
@@ -206,10 +206,10 @@ def run_rule(rule, all_folders):
                     subjects,
                     key=lambda s: s['message_count'],
                     reverse=True
-                )[:LIMIT]
+                )[:BASIC_ANALYTICS_SUBJECT_LIMIT]
 
-                # print(f"Top {limit} offenders for senders that have sent messages with identical subject lines:")
-                print(f"\n{Fore.BLACK}{Back.GREEN} Top {LIMIT} (or less) offenders for messages with identical subject lines (regardless of sender): {Style.RESET_ALL}\n")
+                # print(f"Top {BASIC_ANALYTICS_SUBJECT_LIMIT} offenders for senders that have sent messages with identical subject lines:")
+                print(f"\n{Fore.BLACK}{Back.GREEN} Top {BASIC_ANALYTICS_SUBJECT_LIMIT} (or less) offenders for messages with identical subject lines (regardless of sender): {Style.RESET_ALL}\n")
 
                 for subject in subjects_sorted_by_message_count:
                     print(f"[ {subject['message_count']:>3} x ] subject: [{subject['subject']}]")
@@ -219,8 +219,6 @@ def run_rule(rule, all_folders):
             elif "sender_analytics" in first_action:
                 # HACK: just a quick dirty implementation
                 print("\n----[ Sender Analytics ]----\n")
-
-                LIMIT = 20
 
                 # HACK: just a quick hacky way to do this
                 messages_grouped_by_sender_email_address = [
@@ -234,9 +232,9 @@ def run_rule(rule, all_folders):
                     reverse=True
                 )
 
-                top_senders = sender_email_addresses_by_sent[:LIMIT]
+                top_senders = sender_email_addresses_by_sent[:SENDER_ANALYTICS_SENDER_LIMIT]
 
-                print(f"\n{Fore.BLACK}{Back.GREEN} Top {LIMIT} (or less) offenders for senders that sent the most messages: {Style.RESET_ALL}\n")
+                print(f"\n{Fore.BLACK}{Back.GREEN} Top {SENDER_ANALYTICS_SENDER_LIMIT} (or less) offenders for senders that sent the most messages: {Style.RESET_ALL}\n")
 
                 highest_message_count_chars = len(str(top_senders[0]['sender_message_count']))
                 # HACK: sorry, lol

--- a/outlookcustomtasks/__main__.py
+++ b/outlookcustomtasks/__main__.py
@@ -306,7 +306,9 @@ def group_by_subject(messages):
 
 def get_sender_email_address(message):
     try:
-        if message.Class == MAIL_ITEM_CLASS_ID:  # Check if the item is a MailItem
+        # Check if the item is an Outlook MailItem
+        if message.Class == MAIL_ITEM_CLASS_ID:
+            # if sender email type is Exchange
             if message.SenderEmailType == 'EX':
                 exchange_user = message.Sender.GetExchangeUser()
                 # if exchange user found
@@ -316,8 +318,10 @@ def get_sender_email_address(message):
                 else:
                     # fall back to SenderEmailAddress
                     return message.SenderEmailAddress
+            # if sender email type ISN'T Exchange
             else:
                 return message.SenderEmailAddress
+        # If item ISN'T an Outlook MailItem
         else:
             try:
                 sender_name = message.SenderName
@@ -326,7 +330,6 @@ def get_sender_email_address(message):
                 sender_name = "[UNKNOWN]"
             finally:
                 return f"[N/A] {message.MessageClass}: {sender_name}"
-
     except KeyboardInterrupt as err:
         raise err
     except Exception as err:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "outlookcustomtasks"
-version = "0.2.0"
+version = "0.2.1"
 description = ""
 authors = ["dp-rp <155602873+dp-rp@users.noreply.github.com>"]
 license = "MIT"


### PR DESCRIPTION
- fix sender email address retrieval for messages where sender email type is Exchange
- fix sender email address retrieval for messages where MessageClass isn't Mail Item (e.g. calendar invites, meeting cancellations, etc.)
- increment version to v2.0.1